### PR TITLE
Let run-flent to run gui and mention in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,3 +25,28 @@ Quick Start
 -----------
 
 See https://flent.org/intro.html#quick-start or doc/quickstart.rst.
+
+
+Running Flent from source code
+------------------------------
+
+You can run Flent directly from source code in twp step:
+
+1. Clone GitHub repo:
+
+.. code-block:: bash
+
+  $ git clone https://github.com/tohojo/flent
+  $ cd flent
+
+2. Run Flent by scripts:
+
+.. code-block:: bash
+
+  $ python3 run-flent
+
+3. Run Flent GUI by scripts:
+
+.. code-block:: bash
+
+  $ python3 run-flent gui

--- a/run-flent
+++ b/run-flent
@@ -26,8 +26,12 @@ from multiprocessing import freeze_support
 
 sys.path.insert(1, os.path.dirname(__file__))
 
-from flent import run_flent
+from flent import run_flent, run_flent_gui
 
 if __name__ == "__main__":
     freeze_support()
-    sys.exit(run_flent())
+
+    if len(sys.argv) == 2 and sys.argv[1] == 'gui':
+        sys.exit(run_flent_gui())
+    else:
+        sys.exit(run_flent())


### PR DESCRIPTION
To make `run-flent` script can run gui directly from source code.