### PR TITLE
gui: Fix matplotlib causing runtime error when open file

### DIFF
--- a/flent/gui.py
+++ b/flent/gui.py
@@ -70,6 +70,7 @@ if plotters.MPL_VER < (1, 4, 2):
     raise RuntimeError("The GUI requires matplotlib version >= 1.4.2 to work.")
 else:
     import matplotlib
+    matplotlib.use("Agg")
 
 FORCE_QT4 = bool(os.getenv("FORCE_QT4", False))
 try:


### PR DESCRIPTION
Commit 46a2154 introduce the bug that completly remove import
matplotlib, and fixed at commit 2d0cd05a. But still have bug when
opening a new data file, it will hang by this:

```
Exception in thread Thread-3:
Traceback (most recent call last):
  File "/usr/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/lib/python3.6/multiprocessing/pool.py", line 463, in _handle_results
    task = get()
  File "/usr/lib/python3.6/multiprocessing/connection.py", line 251, in recv
    return _ForkingPickler.loads(buf.getbuffer())
  File "/usr/lib/python3.6/site-packages/matplotlib/figure.py", line 1688, in __setstate__
    mgr = plt._backend_mod.new_figure_manager_given_figure(num, self)
  File "/usr/lib/python3.6/site-packages/matplotlib/backends/backend_tkagg.py", line 1058, in new_figure_manager_given_figure
    icon_img = Tk.PhotoImage(file=icon_fname)
  File "/usr/lib/python3.6/tkinter/__init__.py", line 3539, in __init__
    Image.__init__(self, 'photo', name, cnf, master, **kw)
  File "/usr/lib/python3.6/tkinter/__init__.py", line 3495, in __init__
    self.tk.call(('image', 'create', imgtype, name,) + options)
RuntimeError: main thread is not in main loop
```

After checking the code, adding one line

    matplotlib.use("Agg")

to fix this problem.
  