### PR TITLE
Add multiple inheritance support for batch files.

### DIFF
--- a/flent/batch.py
+++ b/flent/batch.py
@@ -102,11 +102,12 @@ class BatchRunner(object):
             for name, vals in obj.items():
                 # Expand inheritance
                 if 'inherits' in vals:
-                    if not vals['inherits'] in obj:
-                        raise RuntimeError(
-                            "%s inherits from non-existent parent %s."
-                            % (name, vals['inherits']))
-                    obj[name] = self.inherit(obj[vals['inherits']], vals)
+                    for inh in [x.strip() for x in reversed(vals['inherits'].split(','))]:
+                        if not inh in obj:
+                            raise RuntimeError(
+                                "%s inherits from non-existent parent %s."
+                                % (name, inh))
+                        obj[name] = self.inherit(obj[inh], obj[name])
 
                 # Parse boolean options
                 for k, v in obj[name].items():


### PR DESCRIPTION
I don't know how interested you are in taking this, _but_, this allows sections to inherit from multiple other sections by specifying a comma separated value for inherits, for example:

```
[Batch::global]
abstract = yes
title = ${batch_title}
output_path = batch-${batch_time}-${batch_title}/${batch_name}
batch_title = flent-mi
filename_extra = extra
ip_version = 4
length = 10
hosts = apu2c

[Batch::debug]
abstract = yes
extended_metadata = yes
debug_error = yes
debug_log = yes

[Batch::tcp-upload]
inherits = global, debug
test_name = tcp_1up_noping
disabled = no
```

Batches later in the comma separated list take precedence.

This is a simple example, but I've found that it helps me clean up a batch file where I have several batch sections that share a common configuration, but that can also benefit from importing settings specific to the test being run that is not specific to the configuration. I guess it could help any time settings are needed from more than one inheritance hierarchy.

I haven't explored the various ways that people could shoot themselves in the foot with this, but then again, they don't have to use it, and things should work the same as they do today. :)

Signed-off-by: Pete Heist <pete@heistp.net>