### PR TITLE
batch: Add --batch-no-timestamp command line argument

### DIFF
--- a/flent/batch.py
+++ b/flent/batch.py
@@ -261,12 +261,11 @@ class BatchRunner(object):
                         raise
 
     def gen_filename(self, settings, batch, argset, rep):
-        filename = "batch-%s-%s-%s" % (
-            settings.BATCH_NAME,
-            batch['batch_time'],
-            batch.get('filename_extra', "%s-%s" % (argset, rep))
-        )
-        return clean_path(filename)
+        p = ["batch", settings.BATCH_NAME]
+        if self.settings.BATCH_TIMESTAMP:
+            p.append(batch['batch_time'])
+        p.append(batch.get('filename_extra', "%s-%s" % (argset, rep)))
+        return clean_path("-".join(p))
 
     def expand_argsets(self, batch, argsets, batch_time, batch_name,
                        print_status=True, no_shuffle=False):

--- a/flent/settings.py
+++ b/flent/settings.py
@@ -279,6 +279,13 @@ parser.add_argument(
     help="Do not randomise the order of test runs within each batch.")
 
 parser.add_argument(
+    "--batch-no-timestamp",
+    action="store_false", dest="BATCH_TIMESTAMP",
+    help="Do not add a timestamp to batch output filenames. This keeps filenames "
+    "stable, but requires that the filename_extra variable be unique for each "
+    "test run. Results will be overwritten and a warning emitted if not.")
+
+parser.add_argument(
     "--batch-repetitions", action="store", type=int, dest="BATCH_REPS",
     metavar="REPETITIONS",
     help="Shorthand for --batch-override 'repetitions=REPETITIONS'.")


### PR DESCRIPTION
Re-arranged gen_filename a bit now that some parts of the filename are optional.

Signed-off-by: Pete Heist <pete@heistp.net>