### PR TITLE
metadata: Add parsing of WiFi status information

### DIFF
--- a/flent/metadata.py
+++ b/flent/metadata.py
@@ -138,7 +138,8 @@ def record_metadata(results, extended, hostnames):
     if extended:
         m['IP_ADDRS'] = get_ip_addrs()
         m['GATEWAYS'] = get_gateways()
-
+        m['WIFI_DATA'] = get_wifi_data()
+        
     m['REMOTE_METADATA'] = {}
 
     for h in hostnames:
@@ -166,8 +167,9 @@ def record_metadata(results, extended, hostnames):
         if extended:
             m['REMOTE_METADATA'][h]['IP_ADDRS'] = get_ip_addrs()
             m['REMOTE_METADATA'][h]['GATEWAYS'] = get_gateways()
+            m['REMOTE_METADATA'][h]['WIFI_DATA'] = get_wifi_data()
 
-
+            
 def record_postrun_metadata(results, extended, hostnames):
     m = results.meta()
     get_command_output.set_hostname(None)
@@ -515,26 +517,39 @@ def get_module_versions():
 
     return module_versions
 
+
 def get_wifi_data(iface):
     wifi_data = {}
+
     unwanted_keys = ["Interface", "ifindex", "wdev", "wiphy"]
+
     output = get_command_output("iw dev %s info" % iface)
     if output is not None:
-        for line in output.splitlines():
-            parts = line.split() 
 
-            if parts[0]  in unwanted_keys:
-                continue
-            k,v = parts[0], parts[1]
-            if parts[0] == 'txpower':
-               v = float(parts[1])
-            if parts[0] == 'channel':
-                v = {}
-                v['number'] =int(parts[1])
-                v['band'] = int(parts[2].strip("("));
-                v['width'] = int(parts[5])
-                v['center1'] = int(parts[8])
-                
+        for line in output.splitlines():
+
+            if len(line.strip()) >= 1:
+                parts = line.split() 
+                k,v = parts[0], parts[1]
+
+                if k  in unwanted_keys:
+                  continue
+
+                if k == 'txpower':
+                   v = float(parts[1])
+
+                if k == 'channel':
+                    # This condition will return a dict with all the values of the channel
+		            # Output will be {'addr':..., channel': {'band': 2462, 'center1': 2462, 'number': 11, 'width': 20}, 'ssid':...}
+                    v = {}
+                    v['number'] =int(parts[1])
+                    v['band'] = int(parts[2].strip("("));
+                    v['width'] = int(parts[5])
+                    v['center1'] = int(parts[8])
+
+                if k == "multicast TXQ":
+                    break
+
             wifi_data[k] = v
 
     return wifi_data

--- a/flent/metadata.py
+++ b/flent/metadata.py
@@ -514,3 +514,27 @@ def get_module_versions():
             module_versions[m] = v
 
     return module_versions
+
+def get_wifi_data(iface):
+    wifi_data = {}
+    unwanted_keys = ["Interface", "ifindex", "wdev", "wiphy"]
+    output = get_command_output("iw dev %s info" % iface)
+    if output is not None:
+        for line in output.splitlines():
+            parts = line.split() 
+
+            if parts[0]  in unwanted_keys:
+                continue
+            k,v = parts[0], parts[1]
+            if parts[0] == 'txpower':
+               v = float(parts[1])
+            if parts[0] == 'channel':
+                v = {}
+                v['number'] =int(parts[1])
+                v['band'] = int(parts[2].strip("("));
+                v['width'] = int(parts[5])
+                v['center1'] = int(parts[8])
+                
+            wifi_data[k] = v
+
+    return wifi_data

--- a/flent/runners.py
+++ b/flent/runners.py
@@ -1069,17 +1069,19 @@ class RegexpRunner(ProcessRunner):
     # Parse is split into a stateless class method in _parse to be able to call
     # it from find_binary.
     def parse(self, output, error=""):
-        result, raw_values, metadata = self._parse(output)
+        result, raw_values, metadata = self._parse(output, error)
         self.raw_values = raw_values
         self.metadata.update(metadata)
         return result
 
     @classmethod
-    def _parse(cls, output):
+    def _parse(cls, output, error=None):
         result = []
         raw_values = []
         metadata = {}
         lines = output.split("\n")
+        if error:
+            lines.extend(error.split("\n"))
         for line in lines:
             for regexp in cls.regexes:
                 match = regexp.match(line)


### PR DESCRIPTION
Created a function called get_wifi_data() that gathers information about the wifi status at one dictionary.

Output:
> {'addr': '50:b7:c3:c9:1c:8c',
 'channel': {'band': 2462, 'center1': 2462, 'number': 11, 'width': 20},
 'ssid': 'VIVO-81A0',
 'txpower': 15.0,
 'type': 'managed'}