### PR TITLE
metadata: Add parsing of WiFi status information

### DIFF
--- a/flent/metadata.py
+++ b/flent/metadata.py
@@ -138,6 +138,7 @@ def record_metadata(results, extended, hostnames):
     if extended:
         m['IP_ADDRS'] = get_ip_addrs()
         m['GATEWAYS'] = get_gateways()
+        m['WIFI_DATA'] = get_wifi_data()
 
     m['REMOTE_METADATA'] = {}
 
@@ -166,6 +167,7 @@ def record_metadata(results, extended, hostnames):
         if extended:
             m['REMOTE_METADATA'][h]['IP_ADDRS'] = get_ip_addrs()
             m['REMOTE_METADATA'][h]['GATEWAYS'] = get_gateways()
+            m['REMOTE_METADATA'][h]['WIFI_DATA'] = get_wifi_data()
 
 
 def record_postrun_metadata(results, extended, hostnames):
@@ -514,3 +516,39 @@ def get_module_versions():
             module_versions[m] = v
 
     return module_versions
+
+def get_wifi_data(iface):
+    wifi_data = {}
+
+    unwanted_keys = ["Interface", "ifindex", "wdev", "wiphy"]
+
+    output = get_command_output("iw dev %s info" % iface)
+    if output is not None:
+
+        for line in output.splitlines():
+
+            if len(line.strip()) >= 1:
+                parts = line.split() 
+                k,v = parts[0], parts[1]
+
+                if k  in unwanted_keys:
+                  continue
+
+                if k == 'txpower':
+                   v = float(parts[1])
+
+                if k == 'channel':
+                    # This condition will return a dict with all the values of the channel
+		            # Output will be {'addr':..., channel': {'band': 2462, 'center1': 2462, 'number': 11, 'width': 20}, 'ssid':...}
+                    v = {}
+                    v['number'] =int(parts[1])
+                    v['band'] = int(parts[2].strip("("));
+                    v['width'] = int(parts[5])
+                    v['center1'] = int(parts[8])
+
+                if k == "multicast TXQ":
+                    break
+
+            wifi_data[k] = v
+
+    return wifi_data


### PR DESCRIPTION
Created a function called get_wifi_data() that gathers information about the wifi status at one dictionary.

Output:

    {'addr': '50:b7:c3:c9:1c:8c',
    'channel': {'band': 2462, 'center1': 2462, 'number': 11, 'width': 20},
    'ssid': 'VIVO-81A0',
    'txpower': 15.0,
    'type': 'managed'}