### PR TITLE
runners: Add --send-size flag for netperf send size (-m/-M)

### DIFF
--- a/flent/runners.py
+++ b/flent/runners.py
@@ -956,6 +956,7 @@ class NetperfDemoRunner(ProcessRunner):
         args.setdefault('cong_control',
                         self.settings.TEST_PARAMETERS.get('tcp_cong_control', ''))
         args.setdefault('socket_timeout', self.settings.SOCKET_TIMEOUT)
+        args.setdefault('send_size', self.settings.SEND_SIZE)
 
         if self.settings.SWAP_UPDOWN:
             if self.test == 'TCP_STREAM':
@@ -1030,6 +1031,8 @@ class NetperfDemoRunner(ProcessRunner):
 
         if self.test in ("TCP_STREAM", "TCP_MAERTS"):
             args['format'] = "-f m"
+            if args['send_size']:
+                args['send_size'] = "-m {0} -M {0}".format(args['send_size'])
             self.units = 'Mbits/s'
 
             if args['test'] == 'TCP_STREAM' and self.settings.SOCKET_STATS:
@@ -1050,7 +1053,7 @@ class NetperfDemoRunner(ProcessRunner):
                        "{marking} -H {control_host} -p {control_port} " \
                        "-t {test} -l {length:d} {buffer} {format} " \
                        "{control_local_bind} {extra_args} -- " \
-                       "{socket_timeout} {local_bind} -H {host} -k {output_vars} " \
+                       "{socket_timeout} {send_size} {local_bind} -H {host} -k {output_vars} " \
                        "{cong_control} {extra_test_args}".format(**args)
 
         super(NetperfDemoRunner, self).check()

--- a/flent/settings.py
+++ b/flent/settings.py
@@ -369,6 +369,15 @@ test_group.add_argument(
     "to disable.")
 
 test_group.add_argument(
+    "--send-size",
+    action="store", type=unicode, dest="SEND_SIZE",
+    help="Send size (in bytes) used for TCP tests. netperf uses the socket "
+    "buffer size by default, which if too large can cause spikes in the "
+    "throughput results. Lowering this value will increase CPU usage but "
+    "also improves the fidelity of the throughput results without having "
+    "to decrease the socket buffer size.")
+
+test_group.add_argument(
     "--test-parameter",
     action=Update, type=keyval, dest="TEST_PARAMETERS", metavar='key=value',
     help="Arbitrary test parameter in key=value format. "


### PR DESCRIPTION
This is only a start on what we discussed, as it's over my head at the moment how to make this setting per-flow and have it affect the UDP packet size. Sorry if short on time at the moment to dig into it further. :)

Signed-off-by: Pete Heist <pete@heistp.net>