### PR TITLE
Install instructions for macOS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,19 +11,71 @@ Installing Flent
 Installing Flent can be done in several ways, depending on your operating system:
 
 
-- **Debian and Ubuntu:** ``apt install flent``.
+- **Debian and Ubuntu:**
 
-- **Ubuntu pre-18.04:** Add the `tohojo/flent PPA <https://launchpad.net/~tohojo/+archive/ubuntu/flent>`_.
+    .. code-block:: bash
 
-- **Arch Linux:** Install Flent from `the AUR <https://aur.archlinux.org/packages/flent>`_.
+      apt install flent
+
+- **Ubuntu pre-18.04:**
+
+  Add the `tohojo/flent PPA <https://launchpad.net/~tohojo/+archive/ubuntu/flent>`_.
+
+- **Arch Linux:**
+
+  Install Flent from `the AUR <https://aur.archlinux.org/packages/flent>`_.
+
+- **Other Linux:**
+
+  Install from the `Python Package Index <https://pypi.python.org/pypi/flent>`_:
+  
+    .. code-block:: bash
+
+      pip install flent
 
 - **FreeBSD:**
-  ``pkg install flent`` to install the package or ``cd /usr/ports/net/flent && make install`` to install the port.
 
-- **Other Linux and OSX with Macbrew:** Install from the `Python Package Index <https://pypi.python.org/pypi/flent>`_:
-  ``pip install flent``.
+  Install the package
 
+    .. code-block:: bash
 
+      pkg install flent
+
+  Or install the port
+  
+    .. code-block:: bash
+
+        cd /usr/ports/net/flent && make install
+
+- **macOS:**
+
+  `Homebrew <https://brew.sh/>`_ and Python 3 must be installed (Python 3 can be installed using Homebrew)
+
+  Install the `patched netperf package <https://github.com/kris-anderson/homebrew-netperf>`_
+
+    .. code-block:: bash
+
+      brew tap kris-anderson/netperf
+      brew install netperf-enable-demo
+
+  Install other dependencies
+
+    .. code-block:: bash
+
+      brew install fping
+      pip3 install matplotlib --user
+
+  Install Flent using pip
+
+    .. code-block:: bash
+
+      pip3 install flent --user
+
+  Optional (install this if you want to use `flent-gui`)
+
+    .. code-block:: bash
+
+      pip3 install pyqt5 --user
 
 Quick Start
 -----------

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -2,21 +2,72 @@ Installing Flent
 ----------------
 Installing Flent can be done in several ways, depending on your operating system:
 
-- **Debian and Ubuntu:** ``apt install flent``.
 
-- **Ubuntu pre-18.04:** Add the `tohojo/flent PPA <https://launchpad.net/~tohojo/+archive/ubuntu/flent>`_.
+- **Debian and Ubuntu:**
 
-- **Arch Linux:** Install Flent from `the AUR <https://aur.archlinux.org/packages/flent>`_.
+    .. code-block:: bash
 
-- **Fedora rawhide:** ``dnf install flent``.
+      apt install flent
 
-- **Fedora 28-30:** Add the `tohojo/Flent Copr repository <https://copr.fedorainfracloud.org/coprs/tohojo/Flent/>`_.
+- **Ubuntu pre-18.04:**
+
+  Add the `tohojo/flent PPA <https://launchpad.net/~tohojo/+archive/ubuntu/flent>`_.
+
+- **Arch Linux:**
+
+  Install Flent from `the AUR <https://aur.archlinux.org/packages/flent>`_.
+
+- **Other Linux:**
+
+  Install from the `Python Package Index <https://pypi.python.org/pypi/flent>`_:
+  
+    .. code-block:: bash
+
+      pip install flent
 
 - **FreeBSD:**
-  ``pkg install flent`` to install the package or ``cd /usr/ports/net/flent && make install`` to install the port.
 
-- **Other Linux and OSX with Macbrew:** Install from the `Python Package Index <https://pypi.python.org/pypi/flent>`_:
-  ``pip install flent``.
+  Install the package
+
+    .. code-block:: bash
+
+      pkg install flent
+
+  Or install the port
+  
+    .. code-block:: bash
+
+        cd /usr/ports/net/flent && make install
+
+- **macOS:**
+
+  `Homebrew <https://brew.sh/>`_ and Python 3 must be installed (Python 3 can be installed using Homebrew)
+
+  Install the `patched netperf package <https://github.com/kris-anderson/homebrew-netperf>`_
+
+    .. code-block:: bash
+
+      brew tap kris-anderson/netperf
+      brew install netperf-enable-demo
+
+  Install other dependencies
+
+    .. code-block:: bash
+
+      brew install fping
+      pip3 install matplotlib --user
+
+  Install Flent using pip
+
+    .. code-block:: bash
+
+      pip3 install flent --user
+
+  Optional (install this if you want to use `flent-gui`)
+
+    .. code-block:: bash
+
+      pip3 install pyqt5 --user
 
 Quick start
 -----------
@@ -31,6 +82,12 @@ You must run netperf on two computers - a **server** and a **client**.
    *Note:* Instead of installing netperf on a local server, you may substitute
    the netserver that is running on netperf.bufferbloat.net by using :option:`-H
    netperf.bufferbloat.net<-H>` in the commands below.
+
+   List of public hosts you can test against:
+
+   - netperf.bufferbloat.net (also called netperf-east.bufferbloat.net)
+   - netperf-west.bufferbloat.net
+   - netperf-eu.bufferbloat.net
 
 #. **Client (Computer 2):** Install netperf, then install flent on your Client
    computer. When you invoke flent on the Client, it will connect to the


### PR DESCRIPTION
The goal of this PR is to provide macOS users with the necessary steps to install and run Flent successfully.

Some additional things I added:
- cleaned up the documentation a bit to use some code blocks for better readability
- added the three public netperf test servers users can use if they don't run netperf on a machine of their own

This PR was created to address this issue I created:
https://github.com/tohojo/flent/issues/207