### PR TITLE
runners: Bracket IPv6 addresses before passing to irtt

### DIFF
--- a/flent/runners.py
+++ b/flent/runners.py
@@ -1559,7 +1559,7 @@ class IrttRunner(ProcessRunner):
     def __init__(self, host, length, interval=None, ip_version=None,
                  local_bind=None, marking=None, multi_results=False,
                  sample_freq=0, data_size=None, **kwargs):
-        self.host = normalise_host(host)
+        self.host = normalise_host(host, bracket_v6=True)
         self.interval = interval
         self.length = length
         self.ip_version = ip_version

--- a/flent/util.py
+++ b/flent/util.py
@@ -23,6 +23,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import argparse
 import fnmatch
+import ipaddress
 import os
 import re
 import shlex
@@ -225,9 +226,15 @@ def path_components(path):
         folders.insert(0, path)
     return folders
 
-def normalise_host(hostname):
+def normalise_host(hostname, bracket_v6=False):
     if hostname and MULTIHOST_SEP in hostname:
-        return hostname.split(MULTIHOST_SEP, 1)[0]
+        hostname = hostname.split(MULTIHOST_SEP, 1)[0]
+    if bracket_v6:
+        try:
+            ipaddress.IPv6Address(hostname)
+            hostname = "[{}]".format(hostname)
+        except ValueError:
+            pass
     return hostname
 
 def lookup_host(hostname, version=None):


### PR DESCRIPTION
irtt currently only accepts IPv6 addresses surrounded by brackets.
If the host contains an IPv6 address literal (as identified by
ipaddress.IPv6Address), surround the host with brackets before
passing to irtt.

This should address #238.