### PR TITLE
fix: Parsing of raw DITG output in parse_raw

### DIFF
--- a/flent/runners.py
+++ b/flent/runners.py
@@ -791,7 +791,7 @@ class DitgRunner(ProcessRunner):
         raw_values = []
 
         for line in data.splitlines():
-            parts = re.split(r">?\s*", line)
+            parts = list(filter(None, re.split(r"(\S+)>\s*", line)))
             vals = dict(zip(parts[::2], parts[1::2]))
             times = {}
             for v in ('txTime', 'rxTime'):


### PR DESCRIPTION
Fixes #244
Corrected a regex in the parse_raw function which was
leading to a KeyError for txTime and rxTime when running
VoIP tests using DITG.

Signed-off-by: Hrishikesh Athalye <hathalye7@hotmail.com>