### PR TITLE
runners: fix ss data parsing when run along with netserver

### DIFF
--- a/flent/runners.py
+++ b/flent/runners.py
@@ -1863,6 +1863,10 @@ class SsRunner(ProcessRunner):
                      and not self.ss_header_re.search(sp)]
 
         for sp in sub_parts:
+            # Filter out stats from netserver when it's run along with ss
+            if "netserver" in sp:
+                continue
+
             pid = self.pid_re.search(sp)
             if None is pid:
                 continue


### PR DESCRIPTION
When we run netserver along with ss on the same node, ss data parsing breaks. Skip ss stats of netserver user.
