### PR TITLE
Persistent runner lookup cache

### DIFF
--- a/flent/runners.py
+++ b/flent/runners.py
@@ -996,8 +996,8 @@ class NetperfDemoRunner(ProcessRunner):
             elif self.test == 'TCP_MAERTS':
                 self.test = 'TCP_STREAM'
 
-        if self.netperf and not self.remote_host:
-            netperf = self.netperf
+        if self.remote_host in self.netperf:
+            netperf = self.netperf[self.remote_host]
         else:
             nperf = util.which('netperf', fail=RunnerCheckError,
                                remote_host=self.remote_host)
@@ -1029,7 +1029,7 @@ class NetperfDemoRunner(ProcessRunner):
 
             try:
                 # If --test-payload option is specified, use data from that file
-                # else use the default value /dev/urandom. 
+                # else use the default value /dev/urandom.
                 fill_file = args['test_payload']
                 # Sanity check; is /dev/urandom or the custom file readable? If so, use it to
                 # pre-fill netperf's buffers
@@ -1042,11 +1042,9 @@ class NetperfDemoRunner(ProcessRunner):
                     # If the custom file is not readable, fail noisily
                     raise RunnerCheckError("The specified test payload file does not exist or is not readable.")
 
-            if not self.remote_host:
-                # only cache values if we're not executing the checks on a
-                # remote host (since that might differ on subsequent runner
-                # invocations)
-                self.netperf = netperf
+            # cache the value keyed on the remote_host, since the outcome might
+            # differ depending on which host we're running on
+            self.netperf[self.remote_host] = netperf
 
         args['binary'] = netperf['executable']
         args['buffer'] = netperf['buffer']
@@ -2041,7 +2039,7 @@ class TcRunner(ProcessRunner):
                    r"dropped (?P<dropped_pie>\d+) "
                    r"maxq (?P<maxq>\d+) "
                    r"ecn_mark (?P<ecn_mark>\d+)"),
-        
+
         # fq_pie
         re.compile(r"pkts_in (?P<pkts_in>\d+) "
                    r"overlimit (?P<overlimit_pie>\d+) "

--- a/flent/settings.py
+++ b/flent/settings.py
@@ -39,7 +39,7 @@ from flent.build_info import VERSION
 from flent.testenv import TestEnvironment, TEST_PATH
 from flent.loggers import get_logger
 from flent.util import FuncAction, Update, AddHost, append_host, keyval, \
-    keyval_int, keyval_transformer, ArgParser, token_split, CachingDictionary, which
+    keyval_int, keyval_transformer, ArgParser, token_split, global_cache
 from flent.plotters import add_plotting_args
 from flent import loggers, util, resultset, runners
 
@@ -114,17 +114,6 @@ class LogFile(argparse.Action):
         else:
             loggers.setup_logfile(values)
             setattr(namespace, self.dest, values)
-
-
-class CacheFile(argparse.Action):
-
-    def __init__(self, option_strings, dest, level=None, **kwargs):
-        super(CacheFile, self).__init__(option_strings, dest, **kwargs)
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        cache = CachingDictionary(values)
-        which.set_persistent(cache)
-        setattr(namespace, self.dest, cache)
 
 
 class Debug(argparse.Action):
@@ -521,7 +510,7 @@ misc_group.add_argument(
 
 misc_group.add_argument(
     "--cache-file",
-    action=CacheFile, type=unicode, dest="CACHE_FILE",
+    action="store", type=unicode, dest="CACHE_FILE", metavar="FILENAME",
     help="Use this file for caching lookup of runner file names and "
     "versions between runs.")
 
@@ -770,6 +759,9 @@ class Settings(argparse.Namespace):
         # is loaded, this has the desired effect.
         elif self.NEW_GUI_INSTANCE:
             self.GUI = True
+
+        if self.CACHE_FILE:
+            global_cache.read_file(self.CACHE_FILE)
 
         if self.REMOTE_METADATA:
             self.EXTENDED_METADATA = True

--- a/flent/settings.py
+++ b/flent/settings.py
@@ -39,7 +39,7 @@ from flent.build_info import VERSION
 from flent.testenv import TestEnvironment, TEST_PATH
 from flent.loggers import get_logger
 from flent.util import FuncAction, Update, AddHost, append_host, keyval, \
-    keyval_int, keyval_transformer, ArgParser, token_split
+    keyval_int, keyval_transformer, ArgParser, token_split, CachingDictionary, which
 from flent.plotters import add_plotting_args
 from flent import loggers, util, resultset, runners
 
@@ -114,6 +114,17 @@ class LogFile(argparse.Action):
         else:
             loggers.setup_logfile(values)
             setattr(namespace, self.dest, values)
+
+
+class CacheFile(argparse.Action):
+
+    def __init__(self, option_strings, dest, level=None, **kwargs):
+        super(CacheFile, self).__init__(option_strings, dest, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        cache = CachingDictionary(values)
+        which.set_persistent(cache)
+        setattr(namespace, self.dest, cache)
 
 
 class Debug(argparse.Action):
@@ -507,6 +518,12 @@ misc_group.add_argument(
     help="Write debug log (test program output) to log file. If the option is "
     "enabled but no file name is given, the log file name is derived from the "
     "test data filename.")
+
+misc_group.add_argument(
+    "--cache-file",
+    action=CacheFile, type=unicode, dest="CACHE_FILE",
+    help="Use this file for caching lookup of runner file names and "
+    "versions between runs.")
 
 misc_group.add_argument(
     '--list-tests',


### PR DESCRIPTION
This adds a persistent lookup cache for runner probing results. The primary use case is running many tests on remote hosts, where the per-run probing can add significant test time overhead.