### PR TITLE
Runner scalability

### DIFF
--- a/flent/__init__.py
+++ b/flent/__init__.py
@@ -47,7 +47,7 @@ def run_flent(gui=False):
 
         setup_console()
         logger = get_logger(__name__)
-        logger.debug("Flent executed as %s", sys.argv)
+        logger.debug("Flent executed as %s in PID %d", sys.argv, os.getpid())
 
         try:
             signal.signal(signal.SIGTERM, handle_sigterm)

--- a/flent/aggregators.py
+++ b/flent/aggregators.py
@@ -213,8 +213,7 @@ class Aggregator(object):
                                 "Duplicate key '%s' from child runner" % key)
                         result[key] = v
 
-        except KeyboardInterrupt:
-            logger.debug("Received SIGINT")
+        except BaseException:
             self.kill_runners()
             raise
 
@@ -226,7 +225,7 @@ class Aggregator(object):
 
     def kill_runners(self, graceful=False):
         self.killed = True
-        for t in list(self.threads.values()):
+        for t in self.threads.values():
             t.kill(graceful)
 
     def postprocess(self, result):

--- a/flent/aggregators.py
+++ b/flent/aggregators.py
@@ -133,7 +133,13 @@ class Aggregator(object):
                 self.threads[n] = t
 
             # Start in a separate loop once we're sure we successfully created
-            # all runners
+            # all runners. To prevent fork() from inheriting all the management
+            # threads, run a separate loop to fork off all threads before
+            # starting the actual supervisor threads afterwards
+            for t in self.threads.values():
+                if hasattr(t, "fork"):
+                    t.fork()
+
             for t in self.threads.values():
                 t.start()
 

--- a/flent/aggregators.py
+++ b/flent/aggregators.py
@@ -255,9 +255,15 @@ class Aggregator(object):
         return result, metadata, raw_values
 
     def kill_runners(self, graceful=False):
+        if self.killed:
+            return
+
         self.killed = True
         for t in self.threads.values():
-            t.kill(graceful)
+            t.kill()
+        for t in self.threads.values():
+            if t.is_alive():
+                t.join()
 
     def postprocess(self, result):
         logger.debug("Postprocessing data using %d postprocessors", len(self.postprocessors))

--- a/flent/batch.py
+++ b/flent/batch.py
@@ -515,8 +515,8 @@ class BatchRunner(object):
         logger.info("Starting %s test. Expected run time: %d seconds.",
                     settings.NAME, settings.TOTAL_LENGTH)
 
-        self.agg = aggregators.new(settings)
-        res = self.agg.postprocess(self.agg.aggregate(res))
+        agg = aggregators.new(settings)
+        res = agg.postprocess(agg.aggregate(res))
 
         record_postrun_metadata(res, settings.EXTENDED_METADATA,
                                 settings.REMOTE_METADATA)
@@ -625,10 +625,6 @@ class BatchRunner(object):
 
         self.killed = True
         self.kill_children(force=True)
-        try:
-            self.agg.kill_runners()
-        except AttributeError:
-            pass
 
     def p(self):
         for t in 'args', 'batches', 'commands':

--- a/flent/loggers.py
+++ b/flent/loggers.py
@@ -217,6 +217,7 @@ def setup_console():
     logging.captureWarnings(True)
     logging.getLogger("py.warnings").addFilter(LevelDemoteFilter(DEBUG))
     logging.getLogger("matplotlib.font_manager").addFilter(FilterAll())
+    logging.raiseExceptions = False
 
 
 def set_console_level(level):

--- a/flent/loggers.py
+++ b/flent/loggers.py
@@ -181,6 +181,9 @@ class CachingHandler(Handler):
     def write(self, m):
         pass
 
+    def flush(self):
+        self.cache = []
+
 
 def get_logger(name):
     return logging.getLogger(name)
@@ -304,3 +307,8 @@ def set_queue_handler(queue):
 def enable_exceptions():
     if err_handler is not None:
         err_handler.formatter.format_exceptions = True
+
+
+def flush_cache():
+    if cache_handler is not None:
+        cache_handler.flush()

--- a/flent/runners.py
+++ b/flent/runners.py
@@ -1865,6 +1865,7 @@ class SsRunner(ProcessRunner):
         self.is_dup = False
         self._dup_key = None
         self._parsed_parts = None
+        self._dup_runner = None
         super(SsRunner, self).__init__(**kwargs)
 
     def fork(self):
@@ -2024,6 +2025,7 @@ class SsRunner(ProcessRunner):
             self.command = self.find_binary(self.ip_version, self.host,
                                             self.interval, self.length,
                                             self.target)
+            self.watchdog_timer = self.delay + self.length + 5
 
         self._dup_key = dup_key
         super(SsRunner, self).check()

--- a/flent/runners.py
+++ b/flent/runners.py
@@ -2443,8 +2443,12 @@ class WifiStatsRunner(ProcessRunner):
             raw_values.append(matches)
 
         if self.all_stations:
-            self.test_parameters['wifi_stats_stations'] = ",".join(self.stations)
+            metadata['test_parameters'] = {'wifi_stats_stations': ",".join(self.stations)}
         return results, raw_values, metadata
+
+    def post_parse(self):
+        self.test_parameters = self.metadata.pop('test_parameters', {})
+        super().post_parse()
 
     def check(self):
         self.command = self.find_binary(self.interface, self.interval,

--- a/flent/runners.py
+++ b/flent/runners.py
@@ -456,7 +456,10 @@ class ProcessRunner(RunnerBase):
                 raise RuntimeError("Unable to create temporary files: %s" % e)
 
         self.debug("Forking to run command %s", self.command)
-        pid = os.fork()
+        try:
+            pid = os.fork()
+        except OSError as e:
+            raise RuntimeError(f"{self.name}: Error during fork(): {e}")
 
         if pid == 0:
             signal.signal(signal.SIGTERM, signal.SIG_DFL)

--- a/flent/runners.py
+++ b/flent/runners.py
@@ -1852,10 +1852,6 @@ class SsRunner(ProcessRunner):
             return
 
         self._dup_runner.join()
-        self.debug("Finished", extra={'runner': self})
-
-        self.out = self._dup_runner.out
-        self.err = self._dup_runner.err
 
     def filter_np_parent(self, part):
         parsed_parts = []
@@ -1928,10 +1924,11 @@ class SsRunner(ProcessRunner):
 
         return vals
 
-    def parse(self, output, error=""):
-        if self.is_dup:
-            return [], [], {}
+    def do_parse(self, pool):
+        if not self.is_dup:
+            super().do_parse(pool)
 
+    def parse(self, output, error=""):
         parts = output.split("\n---\n")
         parsed_parts = []
         for part in parts:
@@ -1974,9 +1971,11 @@ class SsRunner(ProcessRunner):
             raw_values.append(rw)
 
         if not results:
-            logger.warning("%s: Found no results for pid %s",
-                           self.__class__.__name__, par_pid,
-                           extra={'runner': self})
+            extra = {'runner': self} if not self.is_dup else None
+            logger.warning("%s%s: Found no results for pid %s",
+                           self.__class__.__name__,
+                           "(dup)" if self.is_dup else "",
+                           par_pid, extra=extra)
         self.result = results
         self.raw_values = raw_values
 

--- a/flent/runners.py
+++ b/flent/runners.py
@@ -437,11 +437,12 @@ class ProcessRunner(RunnerBase, threading.Thread):
         pid = os.fork()
 
         if pid == 0:
+            signal.signal(signal.SIGTERM, signal.SIG_DFL)
+            devnull = os.open(os.devnull, os.O_RDWR)
+            os.dup2(devnull, 1)
             os.dup2(self.stdout.fileno(), 1)
             os.dup2(self.stderr.fileno(), 2)
-            self.stdout.close()
-            self.stderr.close()
-            signal.signal(signal.SIGTERM, signal.SIG_DFL)
+            os.closerange(3, 65535)
 
             try:
                 if self.start_event is not None:

--- a/flent/util.py
+++ b/flent/util.py
@@ -29,6 +29,7 @@ import json
 import os
 import re
 import shlex
+import shutil
 import socket
 import threading
 import time
@@ -321,12 +322,8 @@ class WhichCache:
             logger.debug("which: %s is a full path and executable", executable)
             return executable
 
-        for path in [i.strip('""') for i in os.environ["PATH"].split(os.pathsep)]:
-            filename = os.path.join(path, executable)
-            if not self.is_executable(filename):
-                logger.debug("which: %s is not an executable file", filename)
-                continue
-
+        filename = shutil.which(executable)
+        if filename is not None:
             logger.debug("which: Found %s executable at %s",
                          executable, filename)
             return filename

--- a/unittests/test_parsers.py
+++ b/unittests/test_parsers.py
@@ -466,7 +466,7 @@ class TestParsers(unittest.TestCase):
 
         for data in (CAKE_1TIN, CAKE_4TINS, CAKE_LONG):
             r = self.new_runner("tc")
-            res, raw_values, metadata = r.parse(data)
+            res, raw_values, metadata = r.parse_string(data)
             self.check_res_keys(
                 QDISC_KEYS + ['ecn_mark'], res, raw_keys, raw_values)
             if data == CAKE_LONG:
@@ -476,7 +476,7 @@ class TestParsers(unittest.TestCase):
 
     def test_ingress_parser(self):
         r = self.new_runner("tc")
-        res, raw_values, metadata = r.parse(INGRESS_OUTPUT)
+        res, raw_values, metadata = r.parse_string(INGRESS_OUTPUT)
         self.check_res_keys(QDISC_KEYS, res, [], raw_values)
         self.check_vals(['sent_bytes', 'sent_pkts'], res)
 

--- a/unittests/test_parsers.py
+++ b/unittests/test_parsers.py
@@ -466,9 +466,9 @@ class TestParsers(unittest.TestCase):
 
         for data in (CAKE_1TIN, CAKE_4TINS, CAKE_LONG):
             r = self.new_runner("tc")
-            res = r.parse(data)
+            res, raw_values, metadata = r.parse(data)
             self.check_res_keys(
-                QDISC_KEYS + ['ecn_mark'], res, raw_keys, r.raw_values)
+                QDISC_KEYS + ['ecn_mark'], res, raw_keys, raw_values)
             if data == CAKE_LONG:
                 self.check_vals(check_keys + ['ecn_mark'], res)
             else:
@@ -476,8 +476,8 @@ class TestParsers(unittest.TestCase):
 
     def test_ingress_parser(self):
         r = self.new_runner("tc")
-        res = r.parse(INGRESS_OUTPUT)
-        self.check_res_keys(QDISC_KEYS, res, [], r.raw_values)
+        res, raw_values, metadata = r.parse(INGRESS_OUTPUT)
+        self.check_res_keys(QDISC_KEYS, res, [], raw_values)
         self.check_vals(['sent_bytes', 'sent_pkts'], res)
 
 


### PR DESCRIPTION
This pull request contains a number of fixes that significantly improves the scaling of Flent when spawning a lot of runners:

- Fix the SsRunner to only parse output once when running multiple duplicate runners (i.e., for multiple flows on the same host).
- Move parsing of runner output into separate subprocesses to let it run in parallel without the Python GIL
- Fix a bunch of inefficiencies in the way Flent forks off runner child processes and the Python threads that monitor them
- Fix the behaviour when a test is interrupted so runners are more reliably shut down in a timely manner
- Improve memory usage by only reading the tool output into memory when it is absolutely needed, and keeping it there for as short a time as possible
  - in particular, turn all parsers into stream-based parsers
  - also fix garbage collection of runners after a test is done so data isn't kept in memory

The individual commits contain the details; along with the main changes listed above are various smaller fixes that turned out to be useful along the way.

With these changes it is quite feasible to run a `tcp_nup` test with 1000 flows on my laptop, at least as far as starting the netperf instances is concerned (whether the network can actually handle it is a different matter :) ).