### PR TITLE
Fix dependencies on Fedora

### DIFF
--- a/flent/gui.py
+++ b/flent/gui.py
@@ -89,8 +89,8 @@ try:
     from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT \
         as NavigationToolbar
 
-except ImportError:
-    raise RuntimeError("Unable to find a usable Qt version.")
+except ImportError as e:
+    raise RuntimeError(f"Unable to find a usable Qt version {e}.")
 
 
 # The file selector dialog on OSX is buggy, so switching allowed file extensions

--- a/packaging/rpm/flent.spec
+++ b/packaging/rpm/flent.spec
@@ -11,7 +11,7 @@ Source0:          %{pypi_source}
 
 BuildArch:        noarch
 BuildRequires:    python3-devel python3-sphinx desktop-file-utils libappstream-glib python3-setuptools make
-Recommends:       python3-matplotlib python3-qt5 python3-qtpy
+Recommends:       python3-matplotlib python3-matplotlib-qt5 python3-pyside2 python3-QtPy
 
 %description
 The FLExible Network Tester is a Python wrapper to run multiple simultaneous


### PR DESCRIPTION
Update the RPM .spec to fix the recommended dependencies on Fedora for running
the GUI. Also add the GUI import error message to aid debugging.

Fixes #259.