### PR TITLE
gui: Don't pass floats to progressbar.setValue()

### DIFF
--- a/flent/gui.py
+++ b/flent/gui.py
@@ -1031,7 +1031,7 @@ class NewTestDialog(QDialog):
         if (p, s) == (0, 0):
             if not self.aborted:
                 elapsed = time.time() - self.start_time
-                self.progressBar.setValue(100 * elapsed / self.total_time)
+                self.progressBar.setValue(int(100 * elapsed / self.total_time))
         else:
             fn = os.path.join(self.settings.DATA_DIR,
                               self.settings.DATA_FILENAME)


### PR DESCRIPTION
The Qt ProgressBar::setValue() method expects integers and passing floats
causes a crash. Round the calculation to make sure this doesn't happen.

Fixes #261.