### PR TITLE
runners: Provide default implementation for do_parse()

### DIFF
--- a/flent/runners.py
+++ b/flent/runners.py
@@ -236,7 +236,8 @@ class RunnerBase(object):
         pass
 
     def do_parse(self, pool):
-        pass
+        for c in self._child_runners:
+            c.do_parse(pool)
 
     def post_parse(self):
         for c in self._child_runners:


### PR DESCRIPTION
The change to multi-step parsing broke the parsing in DelegatingRunner
derivatives since their children's parser method never got called. Provide
a default implementation for do_parse() in the BaseRunner class that just
chains to child runners.

Fixes #263.

Signed-off-by: Toke Høiland-Jørgensen <toke@toke.dk>