### PR TITLE
A few tweaks to pickling of plotters and matplotlib init

### DIFF
--- a/flent/gui.py
+++ b/flent/gui.py
@@ -152,6 +152,7 @@ def pool_init_func(settings, queue):
     global USE_ABSOLUTE_TIME
     USE_ABSOLUTE_TIME = settings.ABSOLUTE_TIME
 
+    matplotlib.use("Agg")
     plotters.init_matplotlib("-", settings.USE_MARKERS,
                              settings.LOAD_MATPLOTLIBRC)
     set_queue_handler(queue)

--- a/flent/plotters.py
+++ b/flent/plotters.py
@@ -656,15 +656,11 @@ class Plotter(ArgParam):
             self.figure._original_dpi = self.figure.dpi
 
     def __del__(self):
-        if not self.disable_cleanup:
+        if not getattr(self, "disable_cleanup", False):
             try:
                 pyplot.close(self.figure)
             except Exception:
                 pass
-
-    def __getstate__(self):
-        state = self.__dict__.copy()
-        return state
 
     def init(self, config=None, axis=None):
         if config is not None:


### PR DESCRIPTION
Hopefully fixes some CI test errors on matplotlib 3.5.

Signed-off-by: Toke Høiland-Jørgensen <toke@toke.dk>