### PR TITLE
runners: Fix crash on closing object with no stdout/stderr attributes

### DIFF
--- a/flent/aggregators.py
+++ b/flent/aggregators.py
@@ -208,15 +208,16 @@ class Aggregator(object):
                     res = []
                     for t in self.threads.values():
                         res.extend(t.do_parse(parser_pool))
-                    for r in res:
+                    for i, r in enumerate(res):
+                        print(f"{time.monotonic()}: waiting for parsing result {i+1} of {len(res)}")
                         r.wait()
 
+                    print(f"{time.monotonic()}: joining queue")
+                    queue.join()
                     print(f"{time.monotonic()}: closing pool")
                     parser_pool.close()
                     print(f"{time.monotonic()}: joining pool")
                     parser_pool.join()
-                    print(f"{time.monotonic()}: joining queue")
-                    queue.join()
                     print(f"{time.monotonic()}: done")
 
             for t in self.threads.values():

--- a/flent/aggregators.py
+++ b/flent/aggregators.py
@@ -205,8 +205,11 @@ class Aggregator(object):
                     q_thread.start()
 
                     print(f"{time.monotonic()}: starting parser threads")
+                    res = []
                     for t in self.threads.values():
-                        t.do_parse(parser_pool)
+                        res.extend(t.do_parse(parser_pool))
+                    for r in res:
+                        r.wait()
 
                     print(f"{time.monotonic()}: closing pool")
                     parser_pool.close()

--- a/flent/loggers.py
+++ b/flent/loggers.py
@@ -23,6 +23,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 import sys
+import time, os
 
 from logging import StreamHandler, FileHandler, Formatter
 
@@ -310,6 +311,7 @@ def set_queue_handler(queue):
 
     logging.captureWarnings(True)
     logging.getLogger("py.warnings").addFilter(LevelDemoteFilter(DEBUG))
+    print(f"{time.monotonic()}: {os.getpid()}: Set queue handler")
 
 
 def enable_exceptions():

--- a/flent/loggers.py
+++ b/flent/loggers.py
@@ -306,6 +306,7 @@ def set_queue_handler(queue):
 
     handler = QueueHandler(queue)
     logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
 
     logging.captureWarnings(True)
     logging.getLogger("py.warnings").addFilter(LevelDemoteFilter(DEBUG))

--- a/flent/runners.py
+++ b/flent/runners.py
@@ -279,13 +279,17 @@ class RunnerBase(object):
 
         for c in getattr(self, "_child_runners", []):
             c.close()
-        if self.stdout is not None:
-            self.stdout.close()
-            self.stdout = None
-        if self.stderr is not None:
-            self.stderr.close()
-            self.stderr = None
 
+        stdout = getattr(self, "stdout", None)
+        if stdout is not None:
+            stdout.close()
+
+        stderr = getattr(self, "stderr", None)
+        if stderr is not None:
+            stderr.close()
+
+        self.stdout = None
+        self.stderr = None
         self._closed = True
         self._parent = None # break reference cycle
 


### PR DESCRIPTION
If no file descriptors are passed between processes in the pickled objects,
the unpickled object will lead to a crash because it's missing the
stdout/stderr attributes. Make sure we set them if no FDs are passed
through the pickle/unpickle.

Hopefully fixes #268