### PR TITLE
Disable multiprocess parsing on OSX

### DIFF
--- a/flent/runners.py
+++ b/flent/runners.py
@@ -598,7 +598,22 @@ class ProcessRunner(RunnerBase):
         err = io.StringIO()
         return self.parse(out, err)
 
+    def do_parse_direct(self):
+        try:
+            res = self.parse_output()
+            self.recv_result(res)
+        except Exception as e:
+            self.parse_error(e)
+
+        for c in self._child_runners:
+            c.do_parse(None)
+
+        return []
+
     def do_parse(self, pool):
+        if pool is None:
+            return self.do_parse_direct()
+
         res = [pool.apply_async(self.parse_output,
                                 callback=self.recv_result,
                                 error_callback=self.parse_error)]

--- a/flent/runners.py
+++ b/flent/runners.py
@@ -236,8 +236,10 @@ class RunnerBase(object):
         pass
 
     def do_parse(self, pool):
+        res = []
         for c in self._child_runners:
-            c.do_parse(pool)
+            res.extend(c.do_parse(pool))
+        return res
 
     def post_parse(self):
         for c in self._child_runners:
@@ -597,11 +599,12 @@ class ProcessRunner(RunnerBase):
         return self.parse(out, err)
 
     def do_parse(self, pool):
-        pool.apply_async(self.parse_output,
-                         callback=self.recv_result,
-                         error_callback=self.parse_error)
+        res = [pool.apply_async(self.parse_output,
+                                callback=self.recv_result,
+                                error_callback=self.parse_error)]
         for c in self._child_runners:
-            c.do_parse(pool)
+            res.extend(c.do_parse(pool))
+        return res
 
     def recv_result(self, res):
         result, raw_values, metadata = res
@@ -1961,7 +1964,8 @@ class SsRunner(ProcessRunner):
 
     def do_parse(self, pool):
         if not self.is_dup:
-            super().do_parse(pool)
+            return super().do_parse(pool)
+        return []
 
     def parse(self, output, error):
         parsed_parts = []


### PR DESCRIPTION
Since there seems to be issues with the multiprocessing module on OSX, and attempts to find a workaround has failed, let's just disable the parallel parsing entirely on OSX.

Fixes #268