### PR TITLE
Docs: Update test bursts, bursts_11e description

### DIFF
--- a/flent/tests/bursts.conf
+++ b/flent/tests/bursts.conf
@@ -4,7 +4,7 @@
 
 AGGREGATOR='timeseries'
 TOTAL_LENGTH=LENGTH
-DESCRIPTION="Latency measurements under intermittent UDP bursts"
+DESCRIPTION="Latency measurements under intermittent UDP bursts (requires github.com/tohojo/traffic-gen)"
 DEFAULTS={'PLOT': "ping"}
 
 DATA_SETS = o([

--- a/flent/tests/bursts_11e.conf
+++ b/flent/tests/bursts_11e.conf
@@ -4,7 +4,7 @@
 
 AGGREGATOR='timeseries'
 TOTAL_LENGTH=LENGTH
-DESCRIPTION="802.11e Latency measurements under intermittent UDP bursts"
+DESCRIPTION="802.11e Latency measurements under intermittent UDP bursts (requires github.com/tohojo/traffic-gen)"
 DEFAULTS={'PLOT': "ping"}
 
 DATA_SETS = o([


### PR DESCRIPTION
Add comment mentioned the requirement for the traffic-gen utility, incl. adding a [github.com][0] link.

[0]: github.com/tohojo/traffic-gen