### PR TITLE
Iperf compatibility with iperf 2.0.14a and newer

### DIFF
--- a/flent/tests/udp_flood.conf
+++ b/flent/tests/udp_flood.conf
@@ -5,8 +5,8 @@ TOTAL_LENGTH=LENGTH+2*DELAY
 DESCRIPTION="UDP flood w/ping"
 DEFAULTS={'PLOT': 'totals'}
 
-BW=get_test_parameter("udp_bandwidth", default=[None], split=True)
-PKTSIZE=get_test_parameter("udp_pktsize", default=[None], split=True)
+BW=get_test_parameter("udp_bandwidth", default=None, split=True)
+PKTSIZE=get_test_parameter("udp_pktsize", default=None, split=True)
 
 DATA_SETS = o([
         ('UDP upload',


### PR DESCRIPTION
 iperf compatibility with iperf 2.0.14a and newer

The iperf binary deprecated the --enhancedreports from version 2.0.14a
and onwards with the --enhanced flag.

Version 2.0.14a of iperf2 prints the -h help message to stderr, while
later versions print it to stdout.

More recent versions of iperf2 add CSV headers to the CSV output and
append timezone data to the timestamps.
