### PR TITLE
Add Dockerfile

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -3,7 +3,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN sed -i -e's/ main/ main contrib non-free/g' /etc/apt/sources.list.d/debian.sources \
     && apt update \
-    && apt-get install -y netperf iperf3 iputils-ping wget \
+    && apt-get install -y netperf iputils-ping irtt \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:slim
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN sed -i -e's/ main/ main contrib non-free/g' /etc/apt/sources.list.d/debian.sources \
+    && apt update \
+    && apt-get install -y netperf iperf3 iputils-ping wget \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir matplotlib flent 
+
+ENTRYPOINT ["flent"]


### PR DESCRIPTION
This PR adds a Dockerfile example for CLI-only usage of flent. 
The resulting docker-image is Debian (Bookworm) -based, 333MB in total.
Closes #220.