### PR TITLE
Fixed log-scale matplotlib compatibility for v3.3

### DIFF
--- a/flent/plotters.py
+++ b/flent/plotters.py
@@ -1238,7 +1238,10 @@ class Plotter(ArgParam):
             axis.set_ylim(0, top_scale)
         else:
             if self.log_base:
-                axis.set_yscale('log', basey=self.log_base)
+                try:
+                    axis.set_yscale('log', base=self.log_base)
+                except TypeError:
+                    axis.set_yscale('log', basey=self.log_base)
                 axis.set_ylim(max(0, btm_scale), top_scale)
             else:
                 axis.set_ylim(btm_scale, top_scale)
@@ -1884,7 +1887,10 @@ class CdfPlotter(Plotter):
             axis.set_xlim(left=min(min_value, axis.get_xlim()[0]))
 
         if self.log_base:
-            axis.set_xscale('log', basex=self.log_base)
+            try:
+                axis.set_xscale('log', base=self.log_base)
+            except TypeError:
+                axis.set_xscale('log', basex=self.log_base)
 
         for a, b in zip(config['axes'], self.bounds_x):
             a.set_xbound(b)


### PR DESCRIPTION
The matplotlib package removed all axis directions from the base parameters for logarithmic scaling functions in v3.3.0 and up.

This commit supports both the original "basex" and "basey" parameters for older versions of matplotlib and the new "base" parameter for more recent versions of matplotlib.