### PR TITLE
gui: Don't try to redraw received plot if widget was removed

### DIFF
--- a/flent/gui.py
+++ b/flent/gui.py
@@ -2090,6 +2090,7 @@ class ResultWidget(QWidget):
         self.plotter = None
         self.canvas = None
         self.needs_resize = False
+        self.was_destroyed = False
 
         self.new_plot.connect(self.get_plotter)
         self.async_fig = None
@@ -2179,6 +2180,7 @@ class ResultWidget(QWidget):
     def disconnect_all(self):
         for s in (self.update_start, self.update_end, self.plot_changed):
             s.disconnect()
+        self.was_destroyed = True
 
     def disable_cleanup(self):
         if self.plotter is not None:
@@ -2336,6 +2338,8 @@ class ResultWidget(QWidget):
         self.setCursor(Qt.WaitCursor)
 
     def recv_plot(self, fig):
+        if self.was_destroyed:
+            return
         self.new_plot.emit()
 
     def get_plotter(self):


### PR DESCRIPTION
@mahsan76 reports:

> There is an issue in Flent 2.0.1 , after loading multiple test files ( e.g 5 or 6 ) and adding combining them,
> when i click close all tab , it works ok and all tabs are closed...
> but then when i want to open 5 or 6 files again , the process gets stuck with the following exception in ubuntu bash terminal:
> 
> #########################################################################################
> Exception in thread Thread-3:
> Traceback (most recent call last):
>   File "/usr/lib/python3.9/threading.py", line 954, in _bootstrap_inner
>     self.run()
>   File "/usr/lib/python3.9/threading.py", line 892, in run
>     self._target(*self._args, **self._kwargs)
>   File "/usr/lib/python3.9/multiprocessing/pool.py", line 592, in _handle_results
>     cache[job]._set(i, obj)
>   File "/usr/lib/python3.9/multiprocessing/pool.py", line 776, in _set
>     self._callback(self._value)
>   File "/usr/share/flent/flent/gui.py", line 2329, in recv_plot
>     self.new_plot.emit()
> RuntimeError: wrapped C/C++ object of type ResultWidget has been deleted


Fix this by keeping track of when a widget is destroyed, and cancel any plot updates after this happens.