### PR TITLE
Fix running on Python 3.12

### DIFF
--- a/.github/workflows/selftests.yml
+++ b/.github/workflows/selftests.yml
@@ -12,13 +12,27 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11"]
-        matplotlib: ["3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        matplotlib: ["3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.8"]
         pyqt: ["PyQt5", "PySide2"]
         exclude:
+          - python: "3.8"
+            matplotlib: "3.8"
+          - python: "3.11"
+            matplotlib: "3.1"
+          - python: "3.11"
+            matplotlib: "3.2"
           - python: "3.11"
             matplotlib: "3.3"
           - python: "3.11"
+            matplotlib: "3.4"
+          - python: "3.12"
+            matplotlib: "3.1"
+          - python: "3.12"
+            matplotlib: "3.2"
+          - python: "3.12"
+            matplotlib: "3.3"
+          - python: "3.12"
             matplotlib: "3.4"
       fail-fast: false
 

--- a/.github/workflows/selftests.yml
+++ b/.github/workflows/selftests.yml
@@ -34,6 +34,11 @@ jobs:
             matplotlib: "3.3"
           - python: "3.12"
             matplotlib: "3.4"
+          - python: "3.11"
+            matplotlib: "3.7"
+            pyqt: "PySide2"
+          - python: "3.12"
+            pyqt: "PySide2"
       fail-fast: false
 
     env:

--- a/.github/workflows/selftests.yml
+++ b/.github/workflows/selftests.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get install -y xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-shape0 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0
-          pip install QtPy ${PYQT} "matplotlib==${MATPLOTLIB_VERSION}.*"
+          pip install setuptools QtPy ${PYQT} "matplotlib==${MATPLOTLIB_VERSION}.*"
       - name: Run tests
         uses: GabrielBB/xvfb-action@v1
         with:

--- a/flent/plotters.py
+++ b/flent/plotters.py
@@ -39,7 +39,6 @@ from argparse import SUPPRESS
 from functools import reduce
 from itertools import cycle, islice, chain
 from collections import OrderedDict
-from distutils.version import LooseVersion
 
 logger = get_logger(__name__)
 
@@ -47,15 +46,14 @@ try:
     import matplotlib
     import numpy as np
     HAS_MATPLOTLIB = True
-    MPL_VER = LooseVersion(matplotlib.__version__)
-    if MPL_VER < LooseVersion("1.5"):
+    mpl_maj, _ = matplotlib.__version__.split(".", 1)
+    if mpl_maj in ('1', '2'):
         logger.warning("Cannot use old matplotlib version %s, please upgrade!",
                        matplotlib.__version__)
         raise ImportError("Matplotlib %s too old" % matplotlib.__version__)
 except ImportError as e:
     logger.debug("Unable to import matplotlib: %s", e)
     HAS_MATPLOTLIB = False
-    MPL_VER = LooseVersion("0")
 
 PLOT_KWARGS = (
     'alpha',

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [bdist_wheel]
 universal=1
 [test]
-test-suite=unittests.test_suite
+test_suite=unittests.test_suite
 [flake8]
 exclude=doc,build,dist,__pycache__,.git
 max-line-length=82


### PR DESCRIPTION
The distutils module was deprecated in Python 3.12, so let's stop using it.

Fixes #296.