### PR TITLE
Fix SyntaxWarning for '\w' '\d' in regexes

### DIFF
--- a/flent/metadata.py
+++ b/flent/metadata.py
@@ -244,7 +244,7 @@ def get_link_params(iface):
         output = get_command_output("ifconfig %s" % iface)
 
     if output is not None:
-        m = re.search("(qlen|txqueuelen) (\d+)", output)
+        m = re.search(r"(qlen|txqueuelen) (\d+)", output)
         if m:
             link_params['qlen'] = m.group(2)
         m = re.search("ether ([0-9a-f:]{17})", output)
@@ -256,7 +256,7 @@ def get_link_params(iface):
         m = re.search("Speed: ([0-9]+Mb/s)", output)
         if m:
             link_params['speed'] = m.group(1)
-        m = re.search("Duplex: (\w+)", output)
+        m = re.search(r"Duplex: (\w+)", output)
         if m:
             link_params['duplex'] = m.group(1)
 

--- a/flent/metadata.py
+++ b/flent/metadata.py
@@ -207,7 +207,7 @@ def get_ip_addrs(iface=None):
             cmd += " %s" % iface
         output = get_command_output(cmd)
 
-    iface_re = re.compile('^([0-9]+: )?([a-z0-9-]+):')
+    iface_re = re.compile(r'^([0-9]+: )?([a-z0-9-]+):')
 
     if output is not None:
         lines = output.splitlines()
@@ -247,13 +247,13 @@ def get_link_params(iface):
         m = re.search(r"(qlen|txqueuelen) (\d+)", output)
         if m:
             link_params['qlen'] = m.group(2)
-        m = re.search("ether ([0-9a-f:]{17})", output)
+        m = re.search(r"ether ([0-9a-f:]{17})", output)
         if m:
             link_params['ether'] = m.group(1)
 
     output = get_command_output("ethtool %s" % iface)
     if output is not None:
-        m = re.search("Speed: ([0-9]+Mb/s)", output)
+        m = re.search(r"Speed: ([0-9]+Mb/s)", output)
         if m:
             link_params['speed'] = m.group(1)
         m = re.search(r"Duplex: (\w+)", output)

--- a/flent/runners.py
+++ b/flent/runners.py
@@ -1784,7 +1784,7 @@ class IrttRunner(ProcessRunner):
             irtt = util.which('irtt', fail=RunnerCheckError, remote_host=self.remote_host)
 
             out, err = self.run_simple([irtt, 'help', 'client'])
-            if re.search('--[a-z]', out) is None:
+            if re.search(r'--[a-z]', out) is None:
                 raise RunnerCheckError("%s is too old to support gnu style args. "
                                        "Please upgrade to irtt v0.9+." % irtt)
 


### PR DESCRIPTION
Use raw strings literals for the affected regexes

(venv-flent) $ flent -V
/path/to/flent/flent/metadata.py:247: SyntaxWarning: invalid escape sequence '\d'
  m = re.search("(qlen|txqueuelen) (\d+)", output)
/path/to/flent/flent/metadata.py:259: SyntaxWarning: invalid escape sequence '\w'
  m = re.search("Duplex: (\w+)", output)
Starting Flent 2.1.1+git.6c8dce50 using Python 3.12.4. Flent v2.1.1+git.6c8dce50.
Running on Python 3.12.4 (main, Jun  9 2024, 22:05:49) [GCC 13.2.0]. No matplotlib found. Plots won't be available.
No usable Qt version found. GUI won't work.
ERROR: Missing test name.