### PR TITLE
Remove forgotten support for python 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ from glob import glob
 
 version_string = VERSION
 
-if sys.version_info[:3] < (3, 5, 0):
-    sys.stderr.write("Sorry, Flent requires v3.5 or later of Python.\n")
+if sys.version_info[:3] < (3, 6, 0):
+    sys.stderr.write("Sorry, Flent requires v3.6 or later of Python.\n")
     sys.exit(1)
 
 
@@ -112,7 +112,6 @@ classifiers = [
     'Operating System :: POSIX',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3 :: Only',


### PR DESCRIPTION
The last python version deprecation change forgot `setup.py`.
Update that to be on the same level as in `flent/__init__.py`

Fixes: abe88692ca94f5dde96f3ea0889ef2c5035c2a27
Last changed in : 43c82cd01556ef746db608e84eba9a3b5a141aa0