### PR TITLE
Makefile: Don't use 'setup.py test' to run unittests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,11 @@ build: flent/*.py
 
 .PHONY: test
 test:
-	$(PYTHON) setup.py test -r unittests:TestRunner
+	$(PYTHON) -m unittest
 
 .PHONY: test_long
 test_long:
-	$(PYTHON) setup.py test -s unittests.all_tests -r unittests:TestRunner
+	TEST_SUITE=all_tests $(PYTHON) -m unittest
 
 
 .PHONY: install

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,5 @@
 [bdist_wheel]
 universal=1
-[test]
-test_suite=unittests.test_suite
 [flake8]
 exclude=doc,build,dist,__pycache__,.git
 max-line-length=82

--- a/unittests/__init__.py
+++ b/unittests/__init__.py
@@ -21,6 +21,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import os
 import unittest
 from . import test_util
 from . import test_formatters
@@ -29,12 +30,6 @@ from . import test_parsers
 from . import test_plotters
 from . import test_tests
 from . import test_gui
-
-
-class TestRunner(unittest.TextTestRunner):
-    def __init__(self, *args, **kwargs):
-        kwargs['verbosity'] = 2
-        super(TestRunner, self).__init__(*args, **kwargs)
 
 
 test_suite = unittest.TestSuite([test_util.test_suite,
@@ -47,3 +42,12 @@ test_suite = unittest.TestSuite([test_util.test_suite,
                                  ])
 
 all_tests = unittest.TestSuite([test_suite, test_plotters.plot_suite])
+
+def load_tests(loader, standard_tests, pattern):
+    suite = os.getenv("TEST_SUITE", None)
+    if suite == "all_tests":
+        return all_tests
+    return test_suite
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Setuptools v72 deprecated the 'setup.py test' command, so stop using that for
running tests. Instead, execute the 'unittest' module directly, using our
protocol to pass the test suite name as an environment variable to the module
test loader.

Signed-off-by: Toke Høiland-Jørgensen <toke@toke.dk>