### PR TITLE
misc: Align tc_iterate behavior

### DIFF
--- a/flent/runners.py
+++ b/flent/runners.py
@@ -2311,12 +2311,11 @@ class TcRunner(ProcessRunner):
             interface = 'eth0'
 
         return "{bash} {script} -i {interface} -I {interval:.2f} " \
-            "-c {count:.0f} -l {length} -H {host}".format(
+            "-l {length} -H {host}".format(
                 bash=bash,
                 script=script,
                 interface=interface,
                 interval=interval,
-                count=length // interval + 1,
                 length=length,
                 host=host)
 

--- a/flent/scripts/tc_iterate.sh
+++ b/flent/scripts/tc_iterate.sh
@@ -1,16 +1,14 @@
 #!/bin/bash
 
 interface=eth0
-count=10
 length=20
 interval=0.1
 command=qdisc
 host=localhost
 
-while getopts "i:c:l:I:C:H:" opt; do
+while getopts "i:l:I:C:H:" opt; do
     case $opt in
         i) interface=$OPTARG ;;
-        c) count=$OPTARG ;;
         l) length=$OPTARG ;;
         I) interval=$OPTARG ;;
         C) command=$OPTARG ;;
@@ -23,7 +21,7 @@ buffer=""
 
 
 command_string=$(cat <<EOF
-which tc_iterate >/dev/null && exec tc_iterate $buffer -i $interface -c $count -I $interval -C $command;
+which tc_iterate >/dev/null && exec tc_iterate $buffer -i $interface -l $length -I $interval -C $command;
 endtime=\$(date -d "$length sec" +%s%N);
 while (( \$(date +%s%N) <= \$endtime )); do
     tc -s $command show dev $interface;

--- a/misc/tc_iterate.c
+++ b/misc/tc_iterate.c
@@ -30,6 +30,7 @@
 #include <iconv.h>
 #include <fcntl.h>
 #include <math.h>
+#include <float.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/timerfd.h>
@@ -123,6 +124,10 @@ int process_options(int argc, char **argv, args *o)
 		default:  usage(NULL);
 		}
 	}
+
+	if (o->finterval <= 0.0)
+		usage("Interval should be > 0 !\n");
+
 	o->interval.tv_sec = floor(o->finterval);
 	o->interval.tv_nsec = (long long) ((o->finterval - o->interval.tv_sec) * NSEC_PER_SEC);
 	return 0;


### PR DESCRIPTION
The execution of tc_iterate.sh can cause different behaviors depending on whether the tc_iterate binary is installed. The tc_iterate prog collects tc statistics "count"-times where as the bash loop runs for "length" seconds. This leads to different measuring durations.

This patch replaces the "count" parameter with the "length" parameter for tc_iterate.c CLI. tc_iterate.c then calculates the "count" based on the length to determine the duration.