### PR TITLE
tests: Support computing Jain's fairness index for tcp_n{up,down}

### DIFF
--- a/flent/tests/tcp_ndown.conf
+++ b/flent/tests/tcp_ndown.conf
@@ -8,15 +8,15 @@ STREAMS=get_test_parameter('download_streams', cast=int)
 
 DATA_SETS = o([
     ('TCP download avg',
-     {'apply_to': [glob("TCP download::*", exclude=["TCP download sum", "TCP download fairness"])],
+     {'apply_to': [glob("TCP download::*")],
       'units': 'Mbits/s',
       'runner': 'average',}),
     ('TCP download sum',
-     {'apply_to': [glob("TCP download::*", exclude=["TCP download avg", "TCP download fairness"])],
+     {'apply_to': [glob("TCP download::*")],
       'units': 'Mbits/s',
       'runner': 'sum',}),
     ('TCP download fairness',
-     {'apply_to': [glob("TCP download*", exclude=["TCP download avg", "TCP download sum"])],
+     {'apply_to': [glob("TCP download::*")],
        'units': 'Idx',
        'runner': 'fairness',}),
     ('Ping (ms) ICMP',

--- a/flent/tests/tcp_ndown.conf
+++ b/flent/tests/tcp_ndown.conf
@@ -8,13 +8,17 @@ STREAMS=get_test_parameter('download_streams', cast=int)
 
 DATA_SETS = o([
     ('TCP download avg',
-     {'apply_to': [glob("TCP download::*", exclude=["TCP download sum"])],
+     {'apply_to': [glob("TCP download::*", exclude=["TCP download sum", "TCP download fairness"])],
       'units': 'Mbits/s',
       'runner': 'average',}),
     ('TCP download sum',
-     {'apply_to': [glob("TCP download::*", exclude=["TCP download avg"])],
+     {'apply_to': [glob("TCP download::*", exclude=["TCP download avg", "TCP download fairness"])],
       'units': 'Mbits/s',
       'runner': 'sum',}),
+    ('TCP download fairness',
+     {'apply_to': [glob("TCP download*", exclude=["TCP download avg", "TCP download sum"])],
+       'units': 'Idx',
+       'runner': 'fairness',}),
     ('Ping (ms) ICMP',
      {'ip_version': IP_VERSION, 'interval': STEP_SIZE, 'length': TOTAL_LENGTH,
       'host': HOST, 'units': 'ms', 'runner': 'ping'}),
@@ -121,6 +125,16 @@ PLOTS = o([
      {'description': 'Download bandwidth combination bar plot',
       'parent': 'box_combine',
       'type': 'bar_combine'}),
+    ('bar_fairness',
+     {'description': 'Jain\'s fairness combined bar plot',
+      'type': 'bar_combine',
+      'cutoff': (DELAY,-DELAY),
+      'group_by': 'groups',
+      'axis_labels': ['Fairness index'],
+      'series': [{'data': 'TCP download fairness',
+                  'label': 'Download fairness',
+                  'combine_mode': 'mean'}]}),
+
     ])
 
 

--- a/flent/tests/tcp_nup.conf
+++ b/flent/tests/tcp_nup.conf
@@ -8,13 +8,17 @@ STREAMS=get_test_parameter('upload_streams', cast=int)
 
 DATA_SETS = o([
     ('TCP upload avg',
-     {'apply_to': [glob("TCP upload::*", exclude=["TCP upload sum"])],
+     {'apply_to': [glob("TCP upload::*", exclude=["TCP upload sum", "TCP upload fairness"])],
       'units': 'Mbits/s',
       'runner': 'average',}),
     ('TCP upload sum',
-     {'apply_to': [glob("TCP upload::*", exclude=["TCP upload avg"])],
+     {'apply_to': [glob("TCP upload::*", exclude=["TCP upload avg", "TCP upload fairness"])],
       'units': 'Mbits/s',
       'runner': 'sum',}),
+    ('TCP upload fairness',
+     {'apply_to': [glob("TCP upload*", exclude=["TCP upload avg", "TCP upload sum"])],
+       'units': 'Idx',
+       'runner': 'fairness',}),
     ('Ping (ms) ICMP',
      {'ip_version': IP_VERSION, 'interval': STEP_SIZE, 'length': TOTAL_LENGTH,
       'host': HOST, 'units': 'ms', 'runner': 'ping'}),
@@ -178,6 +182,17 @@ PLOTS = o([
      {'description': 'Upload bandwidth combination bar plot',
       'parent': 'box_combine',
       'type': 'bar_combine'}),
+
+    ('bar_fairness',
+     {'description': 'Jain\'s fairness combined bar plot',
+      'type': 'bar_combine',
+      'cutoff': (DELAY,-DELAY),
+      'group_by': 'groups',
+      'axis_labels': ['Fairness index'],
+      'series': [{'data': 'TCP upload fairness',
+                  'label': 'Upload fairness',
+                  'combine_mode': 'mean'}]}),
+
     ])
 
 

--- a/flent/tests/tcp_nup.conf
+++ b/flent/tests/tcp_nup.conf
@@ -8,15 +8,15 @@ STREAMS=get_test_parameter('upload_streams', cast=int)
 
 DATA_SETS = o([
     ('TCP upload avg',
-     {'apply_to': [glob("TCP upload::*", exclude=["TCP upload sum", "TCP upload fairness"])],
+     {'apply_to': [glob("TCP upload::*")],
       'units': 'Mbits/s',
       'runner': 'average',}),
     ('TCP upload sum',
-     {'apply_to': [glob("TCP upload::*", exclude=["TCP upload avg", "TCP upload fairness"])],
+     {'apply_to': [glob("TCP upload::*")],
       'units': 'Mbits/s',
       'runner': 'sum',}),
     ('TCP upload fairness',
-     {'apply_to': [glob("TCP upload*", exclude=["TCP upload avg", "TCP upload sum"])],
+     {'apply_to': [glob("TCP upload::*")],
        'units': 'Idx',
        'runner': 'fairness',}),
     ('Ping (ms) ICMP',


### PR DESCRIPTION
The tcp_n{up,down} tests did not include the runners and plot
definitions for Jain's fairness index. Add them, as straight-forward
copies of the definitions from the rtt_fair tests.

Signed-off-by: Toke Høiland-Jørgensen <toke@toke.dk>