### PR TITLE
fix deprecated QDockWidget::AllDockWidgetFeatures

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,10 +27,11 @@ Installing Flent can be done in several ways, depending on your operating system
 
       dnf install flent
 
-- **Gentoo:**
+- **Gentoo:** (supported in `pkalin overlay <https://github.com/thinrope/pkalin>`_)
 
     .. code-block:: bash
 
+      eselect repository enable pkalin && eix-sync
       emerge net-analyzer/flent
 
 - **Nix:**

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -19,10 +19,11 @@ Installing Flent can be done in several ways, depending on your operating system
 
       dnf install flent
 
-- **Gentoo:**
+- **Gentoo:** (supported in `pkalin overlay <https://github.com/thinrope/pkalin>`_)
 
     .. code-block:: bash
 
+      eselect repository enable pkalin && eix-sync
       emerge net-analyzer/flent
 
 - **Nix:**

--- a/flent/gui.py
+++ b/flent/gui.py
@@ -86,9 +86,9 @@ try:
 
     from qtpy.QtNetwork import QLocalSocket, QLocalServer
 
-    from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg \
+    from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg \
         as FigureCanvas
-    from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT \
+    from matplotlib.backends.backend_qtagg import NavigationToolbar2QT \
         as NavigationToolbar
 
 except ImportError as e:

--- a/flent/ui/mainwindow.ui
+++ b/flent/ui/mainwindow.ui
@@ -212,7 +212,7 @@
   <widget class="QStatusBar" name="statusbar"/>
   <widget class="QDockWidget" name="plotDock">
    <property name="features">
-    <set>QDockWidget::AllDockWidgetFeatures</set>
+    <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable|QDockWidget::DockWidgetFloatable</set>
    </property>
    <property name="windowTitle">
     <string>Sele&amp;ct plot</string>


### PR DESCRIPTION
QDockWidget::AllDockWidgetFeatures has been deprecated in Qt5 and missing in Qt6, it can be replaced by
DockWidgetClosable|DockWidgetMovable|DockWidgetFloatable without side-effects.

Reference:
  https://doc.qt.io/archives/qt-5.15/qdockwidget.html#DockWidgetFeature-enum
  https://doc.qt.io/qt-6/qdockwidget.html#DockWidgetFeature-enum

This may be enough to allow running flent-gui under pyqt6 :-)

$ flent-gui
Starting Flent 2.2.0 using Python 3.13.12.
Initialised matplotlib v3.10.8 on numpy v2.4.4.
GUI loaded. Using Qt through pyqt6 v6.10.3.

** NOTE ** Putting this patch directly in my [pkalin](https://github.com/thinrope/pkalin) Gentoo overlay for `net-analyser/flent-2.2.0-r1`, since `dev-python/pyqt5` has been masked.