### PR TITLE
Unifying version display as <PACKAGE>-<VERSION>

### DIFF
--- a/flent/gui.py
+++ b/flent/gui.py
@@ -351,8 +351,8 @@ class MainWindow(QMainWindow):
         QShortcut(QKeySequence("Ctrl+Up"),
                   self).activated.connect(self.prev_plot)
 
-        logger.info("GUI loaded. Using Qt through %s v%s.", qtpy.API,
-                    QtCore.__version__)
+        logger.info("GUI loaded. Using Qt-%s via %s.", QtCore.__version__,
+                    qtpy.API)
 
     def read_log_queue(self):
         while not self.log_queue.empty():

--- a/flent/plotters.py
+++ b/flent/plotters.py
@@ -179,7 +179,7 @@ def init_matplotlib(output, use_markers, load_rc):
         COLOURS = matplotlib.rcParams['axes.color_cycle']
 
     MATPLOTLIB_INIT = True
-    logger.info("Initialised matplotlib v%s on numpy v%s.",
+    logger.info("Initialised matplotlib-%s and numpy-%s.",
                 matplotlib.__version__, np.__version__)
 
 

--- a/flent/settings.py
+++ b/flent/settings.py
@@ -75,19 +75,19 @@ class _LOG_DEFER:
 class Version(FuncAction):
 
     def __call__(*args):
-        logger.info("Flent v%s.\nRunning on Python %s.",
+        logger.info("Flent v%s.\nRunning on Python-%s.",
                     VERSION, sys.version.replace("\n", " "))
         try:
             import matplotlib
             import numpy
-            logger.info("Using matplotlib version %s on numpy %s.",
+            logger.info("Using matplotlib-%s and numpy-%s.",
                         matplotlib.__version__, numpy.__version__)
         except ImportError:
             logger.info("No matplotlib found. Plots won't be available.")
         try:
             import qtpy
             from qtpy import QtCore
-            logger.info("Using Qt: %s v%s.", qtpy.API, QtCore.__version__)
+            logger.info("Using Qt-%s via %s.", QtCore.__version__, qtpy.API)
         except ImportError:
             logger.info("No usable Qt version found. GUI won't work.")
         sys.exit(0)


### PR DESCRIPTION
* clarifying matplotlib and numpy relation
* clarifying qt and qtpy relation

With this applied, e.g. my test system looks like this:

BEFORE:
````text
$ flent --version
Starting Flent 2.2.0+git.5d0fc34c using Python 3.13.13.
Flent v2.2.0+git.5d0fc34c.
Running on Python 3.13.13 (main, May 15 2026, 16:58:03) [GCC 15.2.1 20260214].
Using matplotlib version 3.10.8 on numpy 2.4.4.
Using Qt: pyqt6 v6.10.3.
````

AFTER:
````text
$ flent --version
Starting Flent 2.2.0+git.9fb19938 using Python 3.13.13.
Flent-2.2.0+git.9fb19938.
Running on Python-3.13.13 (main, May 15 2026, 16:58:03) [GCC 15.2.1 20260214].
Using matplotlib-3.10.8 and numpy-2.4.4.
Using Qt-6.10.3 via pyqt6.
````

I find it better to read, but open for comments. If the "vXXX" syntax is better in your opinion, then just the matplotlib<->numpy and qt<->qtpy(or other) needs to be clarified. At least to me `Using Qt: pyqt6 v6.10.3.` does not seem right.