### PR TITLE
aggregators: Don't crash interpolating across gaps in the data

### DIFF
--- a/flent/aggregators.py
+++ b/flent/aggregators.py
@@ -413,6 +413,13 @@ class TimeseriesAggregator(Aggregator):
                             result[n] = None
                         else:
                             result[n] = v_next
+                    elif v_prev is None or v_next is None:
+                        # One of the interpolation anchors is itself a gap in
+                        # the data (e.g. sparse netperf output at low rates with
+                        # latency, see issue #265). We can't interpolate across
+                        # a gap, so leave a gap in the synthetic series here too,
+                        # rather than crashing with a TypeError.
+                        result[n] = None
                     else:
                         # We found the previous and next values; interpolate
                         # between them. We assume that the rate of change dv/dt

--- a/unittests/__init__.py
+++ b/unittests/__init__.py
@@ -24,6 +24,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 import unittest
 from . import test_util
+from . import test_aggregators
 from . import test_formatters
 from . import test_metadata
 from . import test_parsers
@@ -33,6 +34,7 @@ from . import test_gui
 
 
 test_suite = unittest.TestSuite([test_util.test_suite,
+                                 test_aggregators.test_suite,
                                  test_formatters.test_suite,
                                  test_metadata.test_suite,
                                  test_parsers.test_suite,

--- a/unittests/test_aggregators.py
+++ b/unittests/test_aggregators.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+#
+# test_aggregators.py
+#
+# Author:   ooonea <35407790+ooonea@users.noreply.github.com>
+# Date:      9 June 2026
+# Copyright (c) 2026, ooonea
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+from flent import resultset, aggregators
+from flent.settings import parser, Settings, DEFAULT_SETTINGS
+
+
+class TestTimeseriesAggregator(unittest.TestCase):
+
+    def _aggregate(self, measurements, step=0.2):
+        settings = parser.parse_args(args=[],
+                                     namespace=Settings(DEFAULT_SETTINGS))
+        settings.STEP_SIZE = step
+        settings.TOTAL_LENGTH = 10
+
+        agg = aggregators.TimeseriesAggregator(settings)
+        # Inject crafted measurements in place of running actual runners, so we
+        # can exercise the interpolation logic in isolation.
+        agg.collect = lambda: (measurements,
+                               {"series": {}, "test_parameters": {}},
+                               {})
+
+        results = resultset.ResultSet(NAME="test-aggregators",
+                                      DATA_FILENAME="test-aggregators",
+                                      TEST_PARAMETERS={})
+        return agg.aggregate(results)
+
+    def test_interpolation_across_none_gap(self):
+        # A None value in the middle of a series is a gap, as produced by sparse
+        # netperf output at low rates combined with latency (see issue #265).
+        # The None must not be used as a linear-interpolation anchor, which used
+        # to raise "TypeError: unsupported operand type(s) for -: 'NoneType' and
+        # 'float'". The gap should be preserved as None in the output series.
+        measurements = {
+            "TCP upload": [(0.0, 1.0), (0.2, 2.0), (0.4, None),
+                           (0.6, 4.0), (0.8, 5.0)],
+        }
+
+        results = self._aggregate(measurements)
+
+        data = results.series("TCP upload")
+        self.assertTrue(data, "aggregator produced no data points")
+        self.assertIn(None, data, "the data gap should be preserved as None")
+        self.assertTrue(any(v is not None for v in data),
+                        "valid data points should still be interpolated")
+
+
+test_suite = unittest.TestLoader().loadTestsFromTestCase(TestTimeseriesAggregator)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The time series aggregator builds the synthetic "totals"/"avg" series by linearly interpolating each component series onto the common step grid. When a series contains a `None` value — a gap, as produced by sparse netperf output at low rates combined with latency — and that `None` ends up as an interpolation anchor, it computes `dv_dt = (v_next - v_prev) / (t_next - t_prev)` and raises:

```
TypeError: unsupported operand type(s) for -: 'NoneType' and 'float'
```

aborting the whole run in `postprocess(aggregate(...))` **before any data file is written**, so the result is lost.

This is the low-throughput-plus-latency scenario from #265 (which reports the resulting *gaps*); here a gap used as an interpolation anchor crashes the run outright. I hit it reliably running RRUL from a router through an SQM-shaped Starlink uplink (~15 Mbit/s shaped upload + ~60 ms RTT → sparse `TCP_STREAM` samples). It does not reproduce on a clean loopback run (no gaps), which is why it can go unnoticed.

## Fix

The code already guards `t_prev is None` (start/end of a series). This guards the anchor *values* too: when `v_prev` or `v_next` is `None`, leave a gap (`None`) — the same thing already done when the interpolation distance is too long — instead of crashing. The valid-data path is unchanged.

## Test

`unittests/test_aggregators.py` drives `TimeseriesAggregator.aggregate()` with a minimal series containing a `None` gap: it raises the `TypeError` on current `main` and passes with this change.

## Note

This fixes the *crash*; the gaps discussed in #265 remain (interpolating across very sparse data is not well-defined, as you noted there). Happy to adjust the approach.
